### PR TITLE
fixing up build instructions and example

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -3,8 +3,8 @@ import org.freecompany.redline.header.Architecture
 import org.freecompany.redline.header.Os
 import org.freecompany.redline.header.RpmType
 import org.freecompany.redline.payload.Directive
-import org.vafer.jdeb.DebMaker
-import org.vafer.jdeb.StdOutConsole
+//import org.vafer.jdeb.DebMaker
+//import org.vafer.jdeb.StdOutConsole
 import tablesaw.AbstractFileSet
 import tablesaw.RegExFileSet
 import tablesaw.SimpleFileSet

--- a/how_to_build.txt
+++ b/how_to_build.txt
@@ -1,7 +1,7 @@
 Building requires JDK 1.6 or later.
 
 To build set your classpath to the tablesaw jar file like so:
->export CLASSPATH=tools/tablesaw-1.0.4.jar
+>export CLASSPATH=tools/tablesaw-1.2.0.jar
 
 Then to build type
 >java make

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -1,7 +1,7 @@
 #===============================================================================
 # Settings for the carbon server protocol handler
-kairosdb.service.carbon=org.kairosdb.core.carbon.CarbonServerModule
-kairosdb.carbon.tagparser=org.kairosdb.core.carbon.HostTagParser
+kairosdb.service.carbon=org.kairosdb.plugin.carbon.CarbonServerModule
+kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.HostTagParser
 kairosdb.carbon.text.port=2003
 kairosdb.carbon.pickle.port=2004
 


### PR DESCRIPTION
Fixing up the instructions in how-to-build to make the version of tablesaw distributed. 
Updating the example properties file to reflect org.kairosdb.plugins VS org.kairosdb.core.
Commenting out org.vafer.jdeb per comments on the mailing list.
