### PR TITLE
Templates tag parser

### DIFF
--- a/src/main/java/org/kairosdb/plugin/carbon/Template.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/Template.java
@@ -1,0 +1,137 @@
+package org.kairosdb.plugin.carbon;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Template
+{
+	private List<String> tagNames;
+	private Pattern filter;
+	private Pattern metricNamePattern;
+	private Pattern tagsPattern;
+	private String sourceSeparator = ".";
+	private String targetSeparator = ".";
+	private String template;
+	private Map<String, String> staticTags = new HashMap<String, String>();
+
+	public Template(String string) {
+		List<String> parts = Arrays.asList(string.split(" "));
+		if (parts.size() >= 2) {
+			this.filter = Pattern.compile(parts.get(0));
+			this.template = parts.get(1);
+			for(int i = 2; i < parts.size(); i++) {
+				String part = parts.get(i);
+				if (part.matches("^\\[\\S(?:,\\S)?\\]$")) {
+					part = part.replaceAll("([\\[\\]])", "");
+					List<String> separators = new LinkedList<String>(Arrays.asList(part.split(",")));
+					if (separators.size() < 2) { separators.add(separators.get(0)); }
+					this.sourceSeparator = separators.get(0);
+					this.targetSeparator = separators.get(1);
+				} else if (part.matches("^(?:\\w+=\\w+,?)*(?:\\w+=\\w+)$")) {
+					List<String> tags = Arrays.asList(part.split(","));
+					for (String tag : tags) {
+						List<String> tagParts = Arrays.asList(tag.split("="));
+						staticTags.put(tagParts.get(0), tagParts.get(1));
+					}
+				} else {
+					throw new IllegalArgumentException("unknown parameter: " + part);
+				}
+			}
+			buildTemplatePatterns();
+		} else {
+			throw new IllegalArgumentException("less than 2 space separated parts");
+		}
+	}
+
+	public void addTags(CarbonMetric ret, String metricName) {
+		Matcher matcher = tagsPattern.matcher(metricName);
+		matcher.find();
+		for (int i = 1; i <= matcher.groupCount(); i++) {
+			ret.addTag(tagNames.get(i - 1), matcher.group(i));
+		}
+		addStaticTags(ret);
+	}
+
+	public void addStaticTags(CarbonMetric ret) {
+		for (Map.Entry<String, String> tag : staticTags.entrySet()) {
+			ret.addTag(tag.getKey(), tag.getValue());
+		}
+	}
+
+	public String buildMetricName(String metric) {
+		List<String> matches = new ArrayList<String>();
+		Matcher matcher = metricNamePattern.matcher(metric);
+		matcher.find();
+		for(int i = 1; i <= matcher.groupCount(); i++) {
+			matches.add(matcher.group(i));
+		}
+		String r_sourceSep = "\\" + sourceSeparator;
+		String metricName = String.join(targetSeparator, matches);
+		return metricName.replaceAll(r_sourceSep, targetSeparator);
+	}
+
+	private void buildTemplatePatterns() {
+		String r_sourceSep = "\\" + sourceSeparator;
+		String r_skip = "[^" + sourceSeparator + "]*";
+		String r_capture = "(" + r_skip + ")";
+		List<String> templateParts = Arrays.asList(template.split(r_sourceSep));
+
+		List<String> metricNamePatternParts = new ArrayList<String>();
+		List<String> tagsPatternParts = new ArrayList<String>();
+		List<String> tagNames = new ArrayList<String>();
+
+		for (String templatePart : templateParts) {
+			if ("metric".equals(templatePart)) {
+				metricNamePatternParts.add(r_capture);
+				tagsPatternParts.add(r_skip);
+			} else if ("metric*".equals(templatePart)) {
+				metricNamePatternParts.add("(.*)");
+				tagsPatternParts.add(".*");
+			} else {
+				metricNamePatternParts.add(r_skip);
+				if (templatePart.length() > 0) {
+					tagsPatternParts.add(r_capture);
+					tagNames.add(templatePart);
+				} else {
+					tagsPatternParts.add(r_skip);
+				}
+			}
+		}
+
+		this.tagNames = tagNames;
+
+		this.metricNamePattern = Pattern.compile(
+			"^" + String.join(r_sourceSep, metricNamePatternParts) + "$"
+		);
+		this.tagsPattern = Pattern.compile(
+			"^" + String.join(r_sourceSep, tagsPatternParts) + "$"
+		);
+	}
+
+	public Pattern getFilter() { return filter; }
+
+	public Pattern getMetricNamePattern() { return metricNamePattern; }
+
+	public Pattern getTagsPattern() { return tagsPattern; }
+
+	public String getSourceSeparator() { return sourceSeparator; }
+
+	public Map<String,String> getStaticTags() { return staticTags; }
+
+	public String getTargetSeparator() { return targetSeparator; }
+
+	public List<String> getTagNames() { return tagNames; }
+
+	public String getTemplate() { return template; }
+
+	public boolean matches(String metricName) {
+		Matcher matcher = filter.matcher(metricName);
+		return matcher.lookingAt();
+	}
+}

--- a/src/main/java/org/kairosdb/plugin/carbon/Templates.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/Templates.java
@@ -1,0 +1,68 @@
+package org.kairosdb.plugin.carbon;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Templates
+{
+  public static final Logger logger = LoggerFactory.getLogger(Templates.class);
+
+	private static List<String> unknownMetrics = new ArrayList<String>();
+	private static List<Template> templates = new ArrayList<Template>();
+
+	public static void parse(String templates) {
+		List<String> list = Arrays.asList(templates.split(";"));
+		logger.info("Parsing {} template strings", list.size());
+		int count = 0;
+		for (String element : list) {
+			count++;
+			logger.debug("({}) Parsing template string: {}", count, element);
+			try {
+				Template template = new Template(element);
+				logger.debug(
+					"({}) Built template:\n" +
+					"	Separators: Source='{}' Target='{}'\n" +
+					"	Metric name pattern: {}\n" +
+					"	Tags pattern: {}\n" +
+					"	Tag names: {}\n" +
+					"	Static tags: {}",
+					count,
+					template.getSourceSeparator(),
+					template.getTargetSeparator(),
+					template.getMetricNamePattern(),
+					template.getTagsPattern(),
+					template.getTagNames(),
+					template.getStaticTags()
+				);
+				add(template);
+			} catch (IllegalArgumentException e) {
+				String msg = "({}) Invalid template string ({}): {}";
+				logger.warn(msg, count, e.getMessage(), element);
+			}
+		}
+		logger.info("Built {} templates", getList().size());
+	}
+
+	public static void add(Template template) {
+		templates.add(template);
+	}
+
+	public static List<Template> getList() { return templates; }
+
+	public static Template lookup(String metricName) {
+		for (Template template : templates) {
+			if (template.matches(metricName)) {
+				return template;
+			}
+		}
+		if (!unknownMetrics.contains(metricName)) {
+			logger.warn("No template found for metric: {}", metricName);
+			unknownMetrics.add(metricName);
+		}
+		return null;
+	}
+}

--- a/src/main/java/org/kairosdb/plugin/carbon/TemplatesTagParser.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/TemplatesTagParser.java
@@ -1,0 +1,31 @@
+package org.kairosdb.plugin.carbon;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import java.util.Map;
+import java.util.Arrays;
+
+public class TemplatesTagParser implements TagParser
+{
+	@Inject
+	public TemplatesTagParser(
+		@Named("kairosdb.carbon.templatestagparser.templates")String templates
+	)
+	{
+		Templates.parse(templates);
+	}
+
+	@Override
+	public CarbonMetric parseMetricName(String metricName)
+	{
+		Template m_template = Templates.lookup(metricName);
+		if (m_template != null) {
+			CarbonMetric ret = new CarbonMetric(m_template.buildMetricName(metricName));
+			m_template.addTags(ret, metricName);
+			return ret;
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -7,12 +7,17 @@ kairosdb.carbon.text.port=2003
 kairosdb.carbon.pickle.address=0.0.0.0
 kairosdb.carbon.pickle.port=2004
 
-#Determins the size of the buffer to allocate for incoming pickles
+# Determines the size of the buffer to allocate for incoming pickles
 kairosdb.carbon.pickle.max_size=2048
 
+# HostTagParser properties
 kairosdb.carbon.hosttagparser.host_pattern=[^.]*\.([^.]*)\..*
 kairosdb.carbon.hosttagparser.host_replacement=$1
 kairosdb.carbon.hosttagparser.metric_pattern=([^.]*)\.[^.]*\.(.*)
 kairosdb.carbon.hosttagparser.metric_replacement=$1.$2
 
-
+# TemplatesTagParser properties
+kairosdb.carbon.templatestagparser.templates=\
+	^stats.counters.statsd .type.metric*;\
+	^stats.gauges.statsd .type.metric*;\
+	^stats.statsd .metric*


### PR DESCRIPTION
Here is a tag parser based on templates. It is directly inspired by InfluxDB graphite input tag parser (https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md#templates) and uses the same format (except using a semicolon separated string instead of an array of strings and replacing the word `measurement` by `metric`).

It allows to define a tag template to build a custom metric name and assign custom tags from a graphite string.

I didn't write any test because you don't directly test the HostTagParser but just use it to test the server. I can quickly write some.

Here is my real example of how it works with my company's CDN:

With the following template string:
````
^stats.counters.company.cdn ..metric.metric.host.org.app.cache_action.status.metric*
````
I get the following debug log:
````
06-28|14:21:21.571 [main] DEBUG [Templates.java:26] - (1) Found template string:
  Filter pattern: ^stats.counters.company.cdn
  Template pattern: ..metric.metric.host.org.app.cache_action.status.metric*
06-28|14:21:21.573 [main] DEBUG [Templates.java:32] - (1) Built template:
  Metric name pattern: ^[^.]*\.[^.]*\.([^.]*)\.([^.]*)\.[^.]*\.[^.]*\.[^.]*\.[^.]*\.[^.]*\.(.*)$
  Tags pattern: ^[^.]*\.[^.]*\.[^.]*\.[^.]*\.([^.]*)\.([^.]*)\.([^.]*)\.([^.]*)\.([^.]*)\..*$
  Tag names: [host, org, app, cache_action, status]
````

Sending a metric with the following name:
````
stats.counters.company.cdn.server01.Foo1234.Bar2345.miss.200.client_requests
````

Will result in the following tagging:
Metric name: `company_cdn_client_requests`
Tags: `host=server01; org=Foo1234; app=Bar2345; cache_action= miss; status=200`

I can also add some instructions in the readme. 