### PR TITLE
TemplatesTagParser: Improve invalid metrics handling

### DIFF
--- a/src/main/java/org/kairosdb/plugin/carbon/Template.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/Template.java
@@ -23,31 +23,33 @@ public class Template
 
 	public Template(String string) {
 		List<String> parts = Arrays.asList(string.split(" "));
-		if (parts.size() >= 2) {
+		if (parts.size() >= 1) {
 			this.filterSource = parts.get(0);
 			this.filter = Pattern.compile(filterSource);
-			this.template = parts.get(1);
-			for(int i = 2; i < parts.size(); i++) {
-				String part = parts.get(i);
-				if (part.matches("^\\[\\S(?:,\\S)?\\]$")) {
-					part = part.replaceAll("([\\[\\]])", "");
-					List<String> separators = new LinkedList<String>(Arrays.asList(part.split(",")));
-					if (separators.size() < 2) { separators.add(separators.get(0)); }
-					this.sourceSeparator = separators.get(0);
-					this.targetSeparator = separators.get(1);
-				} else if (part.matches("^(?:\\w+=\\w+,?)*(?:\\w+=\\w+)$")) {
-					List<String> tags = Arrays.asList(part.split(","));
-					for (String tag : tags) {
-						List<String> tagParts = Arrays.asList(tag.split("="));
-						staticTags.put(tagParts.get(0), tagParts.get(1));
+			if (parts.size() >= 2) {
+				this.template = parts.get(1);
+				for(int i = 2; i < parts.size(); i++) {
+					String part = parts.get(i);
+					if (part.matches("^\\[\\S(?:,\\S)?\\]$")) {
+						part = part.replaceAll("([\\[\\]])", "");
+						List<String> separators = new LinkedList<String>(Arrays.asList(part.split(",")));
+						if (separators.size() < 2) { separators.add(separators.get(0)); }
+						this.sourceSeparator = separators.get(0);
+						this.targetSeparator = separators.get(1);
+					} else if (part.matches("^(?:\\w+=\\w+,?)*(?:\\w+=\\w+)$")) {
+						List<String> tags = Arrays.asList(part.split(","));
+						for (String tag : tags) {
+							List<String> tagParts = Arrays.asList(tag.split("="));
+							staticTags.put(tagParts.get(0), tagParts.get(1));
+						}
+					} else {
+						throw new IllegalArgumentException("unknown parameter: " + part);
 					}
-				} else {
-					throw new IllegalArgumentException("unknown parameter: " + part);
 				}
+				buildTemplatePatterns();
 			}
-			buildTemplatePatterns();
 		} else {
-			throw new IllegalArgumentException("less than 2 space separated parts");
+			throw new IllegalArgumentException("empty template string");
 		}
 	}
 
@@ -140,6 +142,8 @@ public class Template
 	public List<String> getTagNames() { return tagNames; }
 
 	public String getTemplate() { return template; }
+
+	public boolean has_template() { return template != null; }
 
 	public boolean matches(String metricName) {
 		Matcher matcher = filter.matcher(metricName);

--- a/src/main/java/org/kairosdb/plugin/carbon/Templates.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/Templates.java
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 public class Templates
 {
   public static final Logger logger = LoggerFactory.getLogger(Templates.class);
-
-	private static List<String> unknownMetrics = new ArrayList<String>();
 	private static List<Template> templates = new ArrayList<Template>();
 
 	public static void parse(String templates) {
@@ -58,10 +56,6 @@ public class Templates
 			if (template.matches(metricName)) {
 				return template;
 			}
-		}
-		if (!unknownMetrics.contains(metricName)) {
-			logger.warn("No template found for metric: {}", metricName);
-			unknownMetrics.add(metricName);
 		}
 		return null;
 	}

--- a/src/main/java/org/kairosdb/plugin/carbon/Templates.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/Templates.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 
 public class Templates
 {
-  public static final Logger logger = LoggerFactory.getLogger(Templates.class);
+	public static final Logger logger = LoggerFactory.getLogger(Templates.class);
 	private static List<Template> templates = new ArrayList<Template>();
 
 	public static void parse(String templates) {
@@ -21,21 +21,25 @@ public class Templates
 			logger.debug("({}) Parsing template string: {}", count, element);
 			try {
 				Template template = new Template(element);
-				logger.debug(
-					"({}) Built template:\n" +
-					"	Separators: Source='{}' Target='{}'\n" +
-					"	Metric name pattern: {}\n" +
-					"	Tags pattern: {}\n" +
-					"	Tag names: {}\n" +
-					"	Static tags: {}",
-					count,
-					template.getSourceSeparator(),
-					template.getTargetSeparator(),
-					template.getMetricNamePattern(),
-					template.getTagsPattern(),
-					template.getTagNames(),
-					template.getStaticTags()
-				);
+				if (template.has_template()) {
+					logger.debug(
+						"({}) Built template:\n" +
+						"	Separators: Source='{}' Target='{}'\n" +
+						"	Metric name pattern: {}\n" +
+						"	Tags pattern: {}\n" +
+						"	Tag names: {}\n" +
+						"	Static tags: {}",
+						count,
+						template.getSourceSeparator(),
+						template.getTargetSeparator(),
+						template.getMetricNamePattern(),
+						template.getTagsPattern(),
+						template.getTagNames(),
+						template.getStaticTags()
+					);
+				} else {
+					logger.debug("({}) Built DROP template", count);
+				}
 				add(template);
 			} catch (IllegalArgumentException e) {
 				String msg = "({}) Invalid template string ({}): {}";

--- a/src/main/java/org/kairosdb/plugin/carbon/TemplatesTagParser.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/TemplatesTagParser.java
@@ -30,6 +30,8 @@ public class TemplatesTagParser implements TagParser
 		if (template == null) {
 			ret = invalidMetric(metricName, "no matching template");
 		} else {
+			if (!template.has_template()) { return null; }
+
 			String targetMetric = template.buildMetricName(metricName);
 			if (targetMetric == null) {
 				ret = invalidMetric(metricName, "does not match metric name pattern", template);

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -18,6 +18,8 @@ kairosdb.carbon.hosttagparser.metric_replacement=$1.$2
 
 # TemplatesTagParser properties
 kairosdb.carbon.templatestagparser.templates=\
-	^stats.counters.statsd .type.metric*;\
-	^stats.gauges.statsd .type.metric*;\
-	^stats.statsd .metric*
+	^metric.example.simple .metric.type.metric*;\
+	^metric_example_custom.separator _metric_type_metric* [_];\
+	^metric.example.change_separator .metric.type.metric* [.,_];\
+	^metric.example.static_tags .metric.type.metric* type=static another_tag=static_too;\
+	^metric.example.mix .metric.type.metric* [.,_] type=static

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -22,4 +22,5 @@ kairosdb.carbon.templatestagparser.templates=\
 	^metric_example_custom.separator _metric_type_metric* [_];\
 	^metric.example.change_separator .metric.type.metric* [.,_];\
 	^metric.example.static_tags .metric.type.metric* type=static another_tag=static_too;\
-	^metric.example.mix .metric.type.metric* [.,_] type=static
+	^metric.example.mix .metric.type.metric* [.,_] type=static;\
+	^metric.example.dropped

--- a/src/test/java/org/kairosdb/plugin/carbon/TemplatesTagParserTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/TemplatesTagParserTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kairosdb.plugin.carbon;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kairosdb.core.datapoints.DoubleDataPoint;
+import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datastore.KairosDatastore;
+import org.kairosdb.core.exception.DatastoreException;
+import org.kairosdb.core.exception.KairosDBException;
+import org.kairosdb.util.Tags;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+public class TemplatesTagParserTest
+{
+	private final static int CARBON_PORT = 2003;
+
+	private KairosDatastore m_datastore;
+	private CarbonTextServer m_server;
+	private CarbonClient m_client;
+	private String m_templates;
+
+	@Before
+	public void setupDatastore() throws KairosDBException, IOException
+	{
+		m_datastore = mock(KairosDatastore.class);
+		m_templates =
+			"^test.metric .metric.host.metric*;" +
+			"^test2.metric .metric.host.metric* [.,_];" +
+			"^test3.metric .metric.host.metric* type=static";
+
+		TemplatesTagParser templatesTagParser = new TemplatesTagParser(m_templates);
+
+		m_server = new CarbonTextServer(m_datastore, templatesTagParser, CARBON_PORT);
+		m_server.start();
+
+		m_client = new CarbonClient("127.0.0.1", CARBON_PORT);
+	}
+
+	@After
+	public void shutdown() throws IOException
+	{
+		m_server.stop();
+		m_client.close();
+	}
+
+	@Test
+	public void test_validMetric() throws DatastoreException, InterruptedException
+	{
+		long now = System.currentTimeMillis() / 1000;
+
+		m_client.sendText("test.metric.host_name.name", now, "1234");
+
+		ImmutableSortedMap<String, String> tags = Tags.create()
+				.put("host", "host_name")
+				.build();
+
+		verify(m_datastore, timeout(5000).times(1))
+				.putDataPoint("metric.name", tags,
+						new LongDataPoint(now * 1000, 1234));
+	}
+
+	@Test
+	public void test_changeSeparator() throws DatastoreException, InterruptedException
+	{
+		long now = System.currentTimeMillis() / 1000;
+
+		m_client.sendText("test2.metric.host_name.name", now, "1234");
+
+		ImmutableSortedMap<String, String> tags = Tags.create()
+				.put("host", "host_name")
+				.build();
+
+		verify(m_datastore, timeout(5000).times(1))
+				.putDataPoint("metric_name", tags,
+						new LongDataPoint(now * 1000, 1234));
+	}
+
+	@Test
+	public void test_staticTag() throws DatastoreException, InterruptedException
+	{
+		long now = System.currentTimeMillis() / 1000;
+
+		m_client.sendText("test3.metric.host_name.name", now, "1234");
+
+		ImmutableSortedMap<String, String> tags = Tags.create()
+				.put("host", "host_name")
+				.put("type", "static")
+				.build();
+
+		verify(m_datastore, timeout(5000).times(1))
+				.putDataPoint("metric.name", tags,
+						new LongDataPoint(now * 1000, 1234));
+	}
+
+	@Test
+	public void test_noMatchingTemplate() throws DatastoreException, InterruptedException
+	{
+		long now = System.currentTimeMillis() / 1000;
+
+		m_client.sendText("metric.host_name.name", now, "1234");
+
+		ImmutableSortedMap<String, String> tags = Tags.create()
+				.put("cause", "no matching template")
+				.put("metricName", "metric.host_name.name")
+				.build();
+
+		verify(m_datastore, timeout(5000).times(1))
+				.putDataPoint("invalidMetrics", tags,
+						new LongDataPoint(now * 1000, 1234));
+	}
+
+	@Test
+	public void test_notMatchingNamePattern() throws DatastoreException, InterruptedException
+	{
+		long now = System.currentTimeMillis() / 1000;
+
+		m_client.sendText("test.metric.host_name", now, "1234");
+
+		ImmutableSortedMap<String, String> tags = Tags.create()
+				.put("cause", "does not match metric name pattern")
+				.put("metricName", "test.metric.host_name")
+				.put("templateFilter", "^test.metric")
+				.build();
+
+		verify(m_datastore, timeout(5000).times(1))
+				.putDataPoint("invalidMetrics", tags,
+						new LongDataPoint(now * 1000, 1234));
+	}
+}


### PR DESCRIPTION
Sending a metric that matches a template filter but doesn't match its name of tags pattern raised exceptions with my first implementation.

In addition, as explained in #17, I liked @vamsikorada way of sending invalid metrics in the DB instead of logging them as I did.

This PR brings a fix for the exceptions, invalid metrics handling and minor code refactoring.

As in #17, invalid metrics are sent into `invalidMetrics` metric with the source metric name in `metricName` tag.

I've also added the `cause` tag giving the reason why the metric is invalid (no matching template, not matching name or tags patterns) and the matched template filter in `templateFilter`, if any.
