### PR TITLE
Unable to compile kairos-carbon plugin with newer toolchain of Java

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -4,8 +4,8 @@
 		<!--<ibiblio name="local-m2" m2compatible="true" root="file://${user.home}/.m2/repository" changingPattern=".*SNAPSHOT"/>-->
 		<!--<ibiblio name="my-maven" m2compatible="true" root="http://repo.maven.apache.org/maven2/"/>-->
 		<!--<ibiblio name="staging" m2compatible="true" root="https://oss.sonatype.org/content/repositories/orgkairosdb-1007"/>-->
-		<ibiblio name="snapshots" m2compatible="true" root="http://oss.sonatype.org/content/repositories/snapshots"/>
-		<ibiblio name="central" m2compatible="true"/>
+		<ibiblio name="snapshots" m2compatible="true" root="https://oss.sonatype.org/content/repositories/snapshots"/>
+		<ibiblio name="central" m2compatible="true" root="https://repo1.maven.org/maven2" />
 		<chain name="default">
 			<!--<resolver ref="local-m2"/>-->
 			<resolver ref="central"/>


### PR DESCRIPTION
With a simple change of ivy settings we now support the build on newer toolchains (includes java 8).